### PR TITLE
Make adminer able to create indice and types on elasticsearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+php:
+  - '5.4'
+  - '7.1'
+script:
+  - mkdir source
+  - wget $(grep -o 'https://github.com.*' sources.download) -qO source.tar.gz
+  - tar -C source -zxvf source.tar.gz --strip-components=1
+  - patch -d source -p 1 < adminer-4.3.1-elasticsearch54.patch
+  - php source/compile.php
+  - find -name "*.php" -exec php -l {} \;

--- a/adminer-4.3.1-elasticsearch54.patch
+++ b/adminer-4.3.1-elasticsearch54.patch
@@ -1,5 +1,5 @@
 --- adminer-4.3.1/adminer/drivers/elastic.inc.php	2017-11-13 10:00:30.380883318 -0200
-+++ adminer-4.3.1-elasticsearch54/adminer/drivers/elastic.inc.php	2017-11-20 16:23:29.608073549 -0200
++++ adminer-4.3.1-elasticsearch54/adminer/drivers/elastic.inc.php	2017-11-24 17:14:08.099479846 -0200
 @@ -19,7 +19,8 @@ if (isset($_GET["elastic"])) {
  				@ini_set('track_errors', 1); // @ - may be disabled
  				$file = @file_get_contents($this->_url  . '/' . ltrim($path, '/'), false, stream_context_create(array('http' => array(
@@ -36,7 +36,7 @@
 +
 +			if (count($parts) === 2) {
 +				$id = trim($parts[1]);
-+				$query = "{$type}/{$id}";
++				$query = $type . '/' . $id;
 +				return $this->_conn->query($query, $record, 'POST');
 +			}
 +
@@ -46,7 +46,7 @@
 +		function insert($type, $record) {
 +			$id = ""; // TODO: User should be able to inform _id
 +
-+			$query = "{$type}/{$id}";
++			$query = $type . '/' . $id;
 +			$response = $this->_conn->query($query, $record, 'POST');
 +			$this->_conn->last_id = $response['_id'];
 +			return $response['created'];

--- a/adminer-4.3.1-elasticsearch54.patch
+++ b/adminer-4.3.1-elasticsearch54.patch
@@ -1,14 +1,24 @@
-diff -rup adminer-4.3.1/adminer/drivers/elastic.inc.php adminer-4.3.1-elasticsearch54/adminer/drivers/elastic.inc.php
 --- adminer-4.3.1/adminer/drivers/elastic.inc.php	2017-11-13 10:00:30.380883318 -0200
-+++ adminer-4.3.1-elasticsearch54/adminer/drivers/elastic.inc.php	2017-11-13 09:53:47.427488962 -0200
-@@ -20,6 +20,7 @@ if (isset($_GET["elastic"])) {
++++ adminer-4.3.1-elasticsearch54/adminer/drivers/elastic.inc.php	2017-11-20 16:23:29.608073549 -0200
+@@ -19,7 +19,8 @@ if (isset($_GET["elastic"])) {
+ 				@ini_set('track_errors', 1); // @ - may be disabled
  				$file = @file_get_contents($this->_url  . '/' . ltrim($path, '/'), false, stream_context_create(array('http' => array(
  					'method' => $method,
- 					'content' => json_encode($content),
+-					'content' => json_encode($content),
++					'content' => $content === null ? $content : json_encode($content),
 +					'header' => 'Content-type:application/json',
  					'ignore_errors' => 1, // available since PHP 5.2.10
  				))));
  				if (!$file) {
+@@ -60,7 +61,7 @@ if (isset($_GET["elastic"])) {
+ 
+ 			function connect($server, $username, $password) {
+ 				preg_match('~^(https?://)?(.*)~', $server, $match);
+-				$this->_url = ($match[1] ? $match[1] : "http://") . "$username:$password@$match[2]/";
++				$this->_url = ($match[1] ? $match[1] : "http://") . "$username:$password@$match[2]";
+ 				$return = $this->query('');
+ 				if ($return) {
+ 					$this->server_info = $return['version']['number'];
 @@ -108,6 +109,7 @@ if (isset($_GET["elastic"])) {
  
  		function select($table, $select, $where, $group, $order = array(), $limit = 1, $page = 0, $print = false) {
@@ -26,7 +36,7 @@ diff -rup adminer-4.3.1/adminer/drivers/elastic.inc.php adminer-4.3.1-elasticsea
 +
 +			if (count($parts) === 2) {
 +				$id = trim($parts[1]);
-+				$query = "$type/$id";
++				$query = "{$type}/{$id}";
 +				return $this->_conn->query($query, $record, 'POST');
 +			}
 +
@@ -102,7 +112,60 @@ diff -rup adminer-4.3.1/adminer/drivers/elastic.inc.php adminer-4.3.1-elasticsea
  					return $return[$name];
  				}
  			}
-@@ -367,6 +419,11 @@ if (isset($_GET["elastic"])) {
+@@ -336,16 +388,16 @@ if (isset($_GET["elastic"])) {
+ 		return null;
+ 	}
+ 
+-	/** Create database
++	/** Create index
+ 	* @param string
+ 	* @return mixed
+ 	*/
+ 	function create_database($db) {
+ 		global $connection;
+-		return $connection->rootQuery(urlencode($db), array(), 'PUT');
++		return $connection->rootQuery(urlencode($db), null, 'PUT');
+ 	}
+ 
+-	/** Drop databases
++	/** Remove index
+ 	* @param array
+ 	* @return mixed
+ 	*/
+@@ -354,7 +406,31 @@ if (isset($_GET["elastic"])) {
+ 		return $connection->rootQuery(urlencode(implode(',', $databases)), array(), 'DELETE');
+ 	}
+ 
+-	/** Drop tables
++	/** Alter type
++	* @param array
++	* @return mixed
++	*/
++	function alter_table($table, $name, $fields, $foreign, $comment, $engine, $collation, $auto_increment, $partitioning) {
++		global $connection;
++
++		$properties = array();
++		foreach($fields as $f) {
++			$field_name = trim($f[1][0]);
++			$field_type = trim($f[1][1] ?: "text");
++
++			$properties[$field_name] = array(
++				'type' => $field_type
++			);
++		}
++
++		if(!empty($properties)) {
++			$properties = array('properties' => $properties);
++		}
++
++		return $connection->query("_mapping/{$name}", $properties, 'PUT');
++	}
++
++	/** Drop types
+ 	* @param array
+ 	* @return bool
+ 	*/
+@@ -367,9 +443,26 @@ if (isset($_GET["elastic"])) {
  		return $return;
  	}
  
@@ -114,3 +177,18 @@ diff -rup adminer-4.3.1/adminer/drivers/elastic.inc.php adminer-4.3.1-elasticsea
  	$jush = "elastic";
  	$operators = array("=", "query");
  	$functions = array();
+ 	$grouping = array();
+ 	$edit_functions = array(array("json"));
++
++	$types = array(); ///< @var array ($type => $maximum_unsigned_length, ...)
++	$structured_types = array(); ///< @var array ($description => array($type, ...), ...)
++	foreach (array(
++		lang('Numbers') => array("long" => 3, "integer" => 5, "short" => 8, "byte" => 10, "double" => 20, "float" => 66, "half_float" => 12, "scaled_float" => 21),
++		lang('Date and time') => array("date" => 10),
++		lang('Strings') => array("string" => 65535, "text" => 65535),
++		lang('Binary') => array( "binary" => 255),
++	) as $key => $val) {
++		$types += $val;
++		$structured_types[$key] = array_keys($val);
++	}
+ }


### PR DESCRIPTION
Hello @marclaporte and @pcbaldwin ,

Two new actions is available on this new patch:

i) Create/Delete a new indice;
ii) Create/Delete a new type;
iii) "Compilable" source code;

As adminer was intended to work with SQL databases, some menus does not make sense. I'm still digging on it, but I thing this commit may be useful.

BB